### PR TITLE
Replace test-accounts with sandbox-accounts in examples

### DIFF
--- a/dotnet/scalepoint-id-get-token/Program.cs
+++ b/dotnet/scalepoint-id-get-token/Program.cs
@@ -44,7 +44,7 @@ namespace ScalepointIdGetToken
             var scopes = new[] { scopeName };
 
             // The endpoint hardcoded below is for test environment. More info: https://dev.scalepoint.com/authentication#endpoints
-            var environment = "https://test-accounts.scalepoint.com/connect/token";
+            var environment = "https://sandbox-accounts.scalepoint.com/connect/token";
             var authenticationEndpointForTests = new Uri(environment);
 
             // This example uses Scalepoint OAuth2 client helper library: https://github.com/Scalepoint/oauth-token-net-client

--- a/dotnet/scalepoint-id-get-token/README.md
+++ b/dotnet/scalepoint-id-get-token/README.md
@@ -5,7 +5,7 @@ This example shows the principles behind [Scalepoint Authentication](https://dev
 ## Prerequisites
 
 * [.NET](https://www.microsoft.com/net/download)
-  > This example uses modern .NET tooling, also known as `.NET Core SDK`. You can still target classic Windows-only `.NET Framework` with this SDK and this example targets both `.NET Framework 4.8` and `.NET Standard 2.0`.
+  > This example uses modern .NET tooling, also known as `.NET Core SDK`. You can still target classic Windows-only `.NET Framework` with this SDK and this example targets both `.NET Framework 4.5` and `.NET Standard 2.0`.
 * Self signed X.509 certificate. [Here it is documentation](https://dev.scalepoint.com/authentication/#self-signed-certificate-generation) how you could generate your own.
 
 ## Getting started
@@ -23,5 +23,5 @@ This example shows the principles behind [Scalepoint Authentication](https://dev
 For example:
 
 ```cmd
-dotnet run --framework net48 "future_insurance" "ClientCertificate.pfx" "password" "case_integration"
+dotnet run --framework net45 "future_insurance" "ClientCertificate.pfx" "password" "case_integration"
 ```

--- a/dotnet/scalepoint-id-get-token/README.md
+++ b/dotnet/scalepoint-id-get-token/README.md
@@ -5,7 +5,7 @@ This example shows the principles behind [Scalepoint Authentication](https://dev
 ## Prerequisites
 
 * [.NET](https://www.microsoft.com/net/download)
-  > This example uses modern .NET tooling, also known as `.NET Core SDK`. You can still target classic Windows-only `.NET Framework` with this SDK and this example targets both `.NET Framework 4.7` and `.NET Core 2.1`.
+  > This example uses modern .NET tooling, also known as `.NET Core SDK`. You can still target classic Windows-only `.NET Framework` with this SDK and this example targets both `.NET Framework 4.8` and `.NET Standard 2.0`.
 * Self signed X.509 certificate. [Here it is documentation](https://dev.scalepoint.com/authentication/#self-signed-certificate-generation) how you could generate your own.
 
 ## Getting started
@@ -23,5 +23,5 @@ This example shows the principles behind [Scalepoint Authentication](https://dev
 For example:
 
 ```cmd
-dotnet run --framework net47 "future_insurance" "ClientCertificate.pfx" "password" "case_integration"
+dotnet run --framework net48 "future_insurance" "ClientCertificate.pfx" "password" "case_integration"
 ```

--- a/java/scalepoint-id-get-token/src/main/java/com/scalepoint/examples/Application.java
+++ b/java/scalepoint-id-get-token/src/main/java/com/scalepoint/examples/Application.java
@@ -44,9 +44,9 @@ public class Application {
         String[] scopes = { scopeName };
 
         // The endpoint hardcoded below is for test environment. More info: https://dev.scalepoint.com/authentication#endpoints
-        String scalepointTokenUrl = "https://test-accounts.scalepoint.com/connect/token";
+        String scalepointTokenUrl = "https://sandbox-accounts.scalepoint.com/connect/token";
         // If you are going to use a your own proxy please specify it here, otherwise it is the same as tokenUrl
-        String companyProxyTokenUrl = "https://test-accounts.scalepoint.com/connect/token";
+        String companyProxyTokenUrl = "https://sandbox-accounts.scalepoint.com/connect/token";
 
         // This example uses Scalepoint OAuth2 client helper library: https://github.com/Scalepoint/oauth-token-java-client
         // Reuse the instance throughout the application lifecycle


### PR DESCRIPTION
Replaced test-accounts reference with sandbox-accounts due to test-accounts environment shut down.